### PR TITLE
Replace alert with throw error

### DIFF
--- a/server/src/service/weatherService.ts
+++ b/server/src/service/weatherService.ts
@@ -66,7 +66,7 @@ class WeatherService {
   // destructureLocationData method
   private destructureLocationData(cityData: Coordinates): Coordinates {
     if (!cityData) {
-      window.alert('City cannot be found, please try again.');
+      throw new Error('City cannot be found, please try again.');
     }
     
     const { name, lat, lon, country, state } = cityData;


### PR DESCRIPTION
This commits undoes the last commit. I was not able to test the window alert in Insomnia since it is not a browser environment. The window alert did not work as expected, so I put the throw error back.